### PR TITLE
Added a podspec for Obj-C only

### DIFF
--- a/Obj-C Classes/CAPSPageMenu.h
+++ b/Obj-C Classes/CAPSPageMenu.h
@@ -8,6 +8,29 @@
 
 #import <UIKit/UIKit.h>
 
+extern NSString * const CAPSPageMenuOptionSelectionIndicatorHeight;
+extern NSString * const CAPSPageMenuOptionMenuItemSeparatorWidth;
+extern NSString * const CAPSPageMenuOptionScrollMenuBackgroundColor;
+extern NSString * const CAPSPageMenuOptionViewBackgroundColor;
+extern NSString * const CAPSPageMenuOptionBottomMenuHairlineColor;
+extern NSString * const CAPSPageMenuOptionSelectionIndicatorColor;
+extern NSString * const CAPSPageMenuOptionMenuItemSeparatorColor;
+extern NSString * const CAPSPageMenuOptionMenuMargin;
+extern NSString * const CAPSPageMenuOptionMenuHeight;
+extern NSString * const CAPSPageMenuOptionSelectedMenuItemLabelColor;
+extern NSString * const CAPSPageMenuOptionUnselectedMenuItemLabelColor;
+extern NSString * const CAPSPageMenuOptionUseMenuLikeSegmentedControl;
+extern NSString * const CAPSPageMenuOptionMenuItemSeparatorRoundEdges;
+extern NSString * const CAPSPageMenuOptionMenuItemFont;
+extern NSString * const CAPSPageMenuOptionMenuItemSeparatorPercentageHeight;
+extern NSString * const CAPSPageMenuOptionMenuItemWidth;
+extern NSString * const CAPSPageMenuOptionEnableHorizontalBounce;
+extern NSString * const CAPSPageMenuOptionAddBottomMenuHairline;
+extern NSString * const CAPSPageMenuOptionMenuItemWidthBasedOnTitleTextWidth;
+extern NSString * const CAPSPageMenuOptionScrollAnimationDurationOnMenuItemTap;
+extern NSString * const CAPSPageMenuOptionCenterMenuItems;
+extern NSString * const CAPSPageMenuOptionHideTopMenuBar;
+
 @class CAPSPageMenu;
 
 #pragma mark - Delegate functions
@@ -73,28 +96,5 @@
 - (void)moveToPage:(NSInteger)index;
 
 - (instancetype)initWithViewControllers:(NSArray *)viewControllers frame:(CGRect)frame options:(NSDictionary *)options;
-
-extern NSString * const CAPSPageMenuOptionSelectionIndicatorHeight;
-extern NSString * const CAPSPageMenuOptionMenuItemSeparatorWidth;
-extern NSString * const CAPSPageMenuOptionScrollMenuBackgroundColor;
-extern NSString * const CAPSPageMenuOptionViewBackgroundColor;
-extern NSString * const CAPSPageMenuOptionBottomMenuHairlineColor;
-extern NSString * const CAPSPageMenuOptionSelectionIndicatorColor;
-extern NSString * const CAPSPageMenuOptionMenuItemSeparatorColor;
-extern NSString * const CAPSPageMenuOptionMenuMargin;
-extern NSString * const CAPSPageMenuOptionMenuHeight;
-extern NSString * const CAPSPageMenuOptionSelectedMenuItemLabelColor;
-extern NSString * const CAPSPageMenuOptionUnselectedMenuItemLabelColor;
-extern NSString * const CAPSPageMenuOptionUseMenuLikeSegmentedControl;
-extern NSString * const CAPSPageMenuOptionMenuItemSeparatorRoundEdges;
-extern NSString * const CAPSPageMenuOptionMenuItemFont;
-extern NSString * const CAPSPageMenuOptionMenuItemSeparatorPercentageHeight;
-extern NSString * const CAPSPageMenuOptionMenuItemWidth;
-extern NSString * const CAPSPageMenuOptionEnableHorizontalBounce;
-extern NSString * const CAPSPageMenuOptionAddBottomMenuHairline;
-extern NSString * const CAPSPageMenuOptionMenuItemWidthBasedOnTitleTextWidth;
-extern NSString * const CAPSPageMenuOptionScrollAnimationDurationOnMenuItemTap;
-extern NSString * const CAPSPageMenuOptionCenterMenuItems;
-extern NSString * const CAPSPageMenuOptionHideTopMenuBar;
 
 @end

--- a/PageMenu-ObjC.podspec
+++ b/PageMenu-ObjC.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "PageMenu"
+  s.version      = "1.2.9"
+  s.summary      = "A paging menu controller built from other view controllers allowing the user to switch between any kind of view controller."
+  s.homepage     = "https://github.com/uacaps/PageMenu"
+  s.license      = { :type => 'UA', :file => 'LICENSE' }
+  s.author       = { "uacaps" => "nfahl@cs.ua.edu" }
+  s.source       = { :git => "https://github.com/CocoaBob/PageMenu.git" }
+  s.platform     = :ios, '8.0'
+  s.source_files = 'Obj-C\ Classes/*.{h,m}'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Hi, 

Although you've created a Obj-C version in the project, but you didn't create a specific `Podspec` for Obj-C purpose only. For those people who can't use `use_framework`, they have to pull a pure Obj-C version, otherwise Cocoapods won't finish `pod install`.

So I've added another `Podspec` for Obj-C only , and exposed `extern NSString` definitions if the user's main project is written in Swift 2.2.

Best regards,