### PR TITLE
Add Different Font Types for Selected Items

### DIFF
--- a/Classes/CAPSPageMenu.swift
+++ b/Classes/CAPSPageMenu.swift
@@ -73,6 +73,7 @@ public enum CAPSPageMenuOption {
     case UseMenuLikeSegmentedControl(Bool)
     case MenuItemSeparatorRoundEdges(Bool)
     case MenuItemFont(UIFont)
+    case MenuSelectedItemFont(UIFont)
     case MenuItemSeparatorPercentageHeight(CGFloat)
     case MenuItemWidth(CGFloat)
     case EnableHorizontalBounce(Bool)
@@ -117,6 +118,8 @@ public class CAPSPageMenu: UIViewController, UIScrollViewDelegate, UIGestureReco
     public var menuItemSeparatorColor : UIColor = UIColor.lightGrayColor()
     
     public var menuItemFont : UIFont = UIFont.systemFontOfSize(15.0)
+    public var menuSelectedItemFont : UIFont = UIFont.systemFontOfSize(15.0)
+
     public var menuItemSeparatorPercentageHeight : CGFloat = 0.2
     public var menuItemSeparatorWidth : CGFloat = 0.5
     public var menuItemSeparatorRoundEdges : Bool = false
@@ -205,6 +208,8 @@ public class CAPSPageMenu: UIViewController, UIScrollViewDelegate, UIGestureReco
                     menuItemSeparatorRoundEdges = value
                 case let .MenuItemFont(value):
                     menuItemFont = value
+                case let .MenuSelectedItemFont(value):
+                    menuSelectedItemFont = value
                 case let .MenuItemSeparatorPercentageHeight(value):
                     menuItemSeparatorPercentageHeight = value
                 case let .MenuItemWidth(value):
@@ -447,6 +452,8 @@ public class CAPSPageMenu: UIViewController, UIScrollViewDelegate, UIGestureReco
         if menuItems.count > 0 {
             if menuItems[currentPageIndex].titleLabel != nil {
                 menuItems[currentPageIndex].titleLabel!.textColor = selectedMenuItemLabelColor
+                menuItems[currentPageIndex].titleLabel!.font =
+                    menuSelectedItemFont
             }
         }
         

--- a/Obj-C Classes/CAPSPageMenu.h
+++ b/Obj-C Classes/CAPSPageMenu.h
@@ -56,6 +56,7 @@
 @property (nonatomic) UIColor *menuItemSeparatorColor;
 
 @property (nonatomic) UIFont *menuItemFont;
+@property (nonatomic) UIFont *menuSelectedItemFont;
 @property (nonatomic) CGFloat menuItemSeparatorPercentageHeight;
 @property (nonatomic) CGFloat menuItemSeparatorWidth;
 @property (nonatomic) BOOL menuItemSeparatorRoundEdges;
@@ -88,6 +89,7 @@ extern NSString * const CAPSPageMenuOptionUnselectedMenuItemLabelColor;
 extern NSString * const CAPSPageMenuOptionUseMenuLikeSegmentedControl;
 extern NSString * const CAPSPageMenuOptionMenuItemSeparatorRoundEdges;
 extern NSString * const CAPSPageMenuOptionMenuItemFont;
+extern NSString * const CAPSPageMenuOptionMenuSelectedItemFont;
 extern NSString * const CAPSPageMenuOptionMenuItemSeparatorPercentageHeight;
 extern NSString * const CAPSPageMenuOptionMenuItemWidth;
 extern NSString * const CAPSPageMenuOptionEnableHorizontalBounce;

--- a/Obj-C Classes/CAPSPageMenu.m
+++ b/Obj-C Classes/CAPSPageMenu.m
@@ -85,6 +85,7 @@ NSString * const CAPSPageMenuOptionUnselectedMenuItemLabelColor         = @"unse
 NSString * const CAPSPageMenuOptionUseMenuLikeSegmentedControl          = @"useMenuLikeSegmentedControl";
 NSString * const CAPSPageMenuOptionMenuItemSeparatorRoundEdges          = @"menuItemSeparatorRoundEdges";
 NSString * const CAPSPageMenuOptionMenuItemFont                         = @"menuItemFont";
+NSString * const CAPSPageMenuOptionMenuSelectedItemFont					= @"menuSelectedItemFont";
 NSString * const CAPSPageMenuOptionMenuItemSeparatorPercentageHeight    = @"menuItemSeparatorPercentageHeight";
 NSString * const CAPSPageMenuOptionMenuItemWidth                        = @"menuItemWidth";
 NSString * const CAPSPageMenuOptionEnableHorizontalBounce               = @"enableHorizontalBounce";
@@ -135,7 +136,9 @@ NSString * const CAPSPageMenuOptionHideTopMenuBar                       = @"hide
                 _menuItemSeparatorRoundEdges = [options[key] boolValue];
             } else if ([key isEqualToString:CAPSPageMenuOptionMenuItemFont]) {
                 _menuItemFont = options[key];
-            } else if ([key isEqualToString:CAPSPageMenuOptionMenuItemSeparatorPercentageHeight]) {
+            } else if ([key isEqualToString:CAPSPageMenuOptionMenuSelectedItemFont]) {
+            	_menuSelectedItemFont = options[key];
+        	} else if ([key isEqualToString:CAPSPageMenuOptionMenuItemSeparatorPercentageHeight]) {
                 _menuItemSeparatorPercentageHeight = [options[key] floatValue];
             } else if ([key isEqualToString:CAPSPageMenuOptionMenuItemWidth]) {
                 _menuItemWidth = [options[key] floatValue];
@@ -197,6 +200,7 @@ NSString * const CAPSPageMenuOptionHideTopMenuBar                       = @"hide
     _menuItemSeparatorColor       = [UIColor lightGrayColor];
     
     _menuItemFont = [UIFont systemFontOfSize:15.0];
+    _menuSelectedItemFont = [UIFont systemFontOfSize:17.0];
     _menuItemSeparatorPercentageHeight = 0.2;
     _menuItemSeparatorWidth            = 0.5;
     _menuItemSeparatorRoundEdges       = NO;
@@ -399,6 +403,7 @@ NSString * const CAPSPageMenuOptionHideTopMenuBar                       = @"hide
     if (_mutableMenuItems.count > 0) {
         if ([_mutableMenuItems[_currentPageIndex] titleLabel] != nil) {
             [_mutableMenuItems[_currentPageIndex] titleLabel].textColor = _selectedMenuItemLabelColor;
+            [_mutableMenuItems[_currentPageIndex] titleLabel].font = _menuSelectedItemFont;
         }
     }
     


### PR DESCRIPTION
## Overview

This change adds different font types for selected items for both the Objective-C and Swift version of PageMenu.

### Changes

#### Swift
- Add case for `MenuSelectedItemFont`
- Set font based off `currentPageIndex`

#### Objective-C
- Add `CAPSPageMenuOptionMenuSelectedItemFont`
- Set font based off `currentPageIndex`
